### PR TITLE
DigitalOcean DynDNS description update. Close #9602

### DIFF
--- a/src/usr/local/www/services_dyndns_edit.php
+++ b/src/usr/local/www/services_dyndns_edit.php
@@ -315,7 +315,8 @@ $group->setHelp('Enter the complete fully qualified domain name. Example: myhost
 			'GleSYS: Enter the record ID.%1$s' .
 			'DNSimple: Enter only the domain name.%1$s' .
 			'Namecheap, Cloudflare, GratisDNS, Hover, ClouDNS, GoDaddy, Linode: Enter the hostname and the domain separately, with the domain being the domain or subdomain zone being handled by the provider.%1$s' .
-			'Cloudflare, DigitalOcean, Linode: Enter @ as the hostname to indicate an empty field.', '<br />');
+			'DigitalOcean: Enter the record ID as the hostname and the domain separately.%1$s' .
+			'Cloudflare, Linode: Enter @ as the hostname to indicate an empty field.', '<br />');
 
 $section->add($group);
 


### PR DESCRIPTION
The description for DigitalOcean dynamic DNS is incorrect. The documentation currently states to "Enter @ as the hostname to indicate an empty field" but that produces errors since the DigitalOcean record ID is missing. Instead the user should look up their record ID and insert that record ID into the hostname field.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/9602
- [ ] Ready for review